### PR TITLE
Allow user to escape brackets with '\'

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 	<a href="https://github.com/mshang/syntree"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 	<div id="accordion">
 		<h3><a href="#">Syntax Tree Generator</a></h3><div style="text-align:left">
-			<textarea id="i" rows="4">[S [NP This] [VP [V is] [^NP a wug]]]</textarea>
+			<textarea id="i" rows="4">[S [NP This] [VP [V \[is\]] [^NP a wug]]]</textarea>
 			(C) 2011 by <a href="http://mshang.ca/">Miles Shang</a>, see <a href="LICENSE.txt">license</a>.
 		</div>
 		


### PR DESCRIPTION
Brackets are reserved by the syntax tree parser, but some users (such as myself) want to use brackets in  node strings (such as to signify that a value is "virtual"). 

This will ignore brackets preceded with `\` when building the tree, then remove backslashes preceding bracket characters before displaying text. Other backslashes will remain unchanged.
