### PR TITLE
Fixed 'Fork on GitHub' banner moving when scrolling sideways

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
 
 <body>
-	<a href="https://github.com/mshang/syntree"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+	<a href="https://github.com/mshang/syntree"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 	<div id="accordion">
 		<h3><a href="#">Syntax Tree Generator</a></h3><div style="text-align:left">
 			<textarea id="i" rows="4">[S [NP This] [VP [V is] [^NP a wug]]]</textarea>


### PR DESCRIPTION
When the generated tree overflows right, scrolling will move the banner. Changing its position to fixed keeps it in the corner.
